### PR TITLE
Added form fields lazy loading.

### DIFF
--- a/config/webpack.prod.config.js
+++ b/config/webpack.prod.config.js
@@ -10,7 +10,7 @@ const prodConfig = {
         path: resolve('./dist'),
         library: '[name]',
         libraryTarget: 'umd',
-        filename: "index.js"
+        filename: "[name].js"
     },
 }
 

--- a/src/pf-3-form-fields/checkbox-lazy.js
+++ b/src/pf-3-form-fields/checkbox-lazy.js
@@ -1,0 +1,3 @@
+import { CheckboxGroup } from './form-fields';
+
+export default CheckboxGroup;

--- a/src/pf-3-form-fields/component-mapper.js
+++ b/src/pf-3-form-fields/component-mapper.js
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { components } from '../constants';
-import { TextField, TextareaField, CheckboxGroup, RadioGroup, SelectField, SubForm } from './form-fields';
-import { renderArrayField } from '../shared-components/array-form-component';
+
+const renderArrayField = lazy(() => import('../shared-components/array-form-component'));
+const TextField = lazy(() => import('./text-field-lazy'));
+const TextareaField = lazy(() => import('./textarea-lazy'));
+const CheckboxGroup = lazy(() => import('./checkbox-lazy'));
+const RadioGroup = lazy(() => import('./radio-lazy'));
+const SelectField = lazy(() => import('./select-field-lazy'));
+const SubForm = lazy(() => import('./sub-form-lazy'));
 
 const componentMapper = (componentType, formOptions) => ({
   [components.TEXT_FIELD]: props => <TextField { ...props } key={ props.name } />,

--- a/src/pf-3-form-fields/radio-lazy.js
+++ b/src/pf-3-form-fields/radio-lazy.js
@@ -1,0 +1,3 @@
+import { RadioGroup } from './form-fields';
+
+export default RadioGroup;

--- a/src/pf-3-form-fields/select-field-lazy.js
+++ b/src/pf-3-form-fields/select-field-lazy.js
@@ -1,0 +1,3 @@
+import { SelectField } from './form-fields';
+
+export default SelectField;

--- a/src/pf-3-form-fields/sub-form-lazy.js
+++ b/src/pf-3-form-fields/sub-form-lazy.js
@@ -1,0 +1,3 @@
+import { SubForm } from './form-fields';
+
+export default SubForm;

--- a/src/pf-3-form-fields/text-field-lazy.js
+++ b/src/pf-3-form-fields/text-field-lazy.js
@@ -1,0 +1,3 @@
+import { TextField } from './form-fields';
+
+export default TextField;

--- a/src/pf-3-form-fields/textarea-lazy.js
+++ b/src/pf-3-form-fields/textarea-lazy.js
@@ -1,0 +1,3 @@
+import { TextareaField } from './form-fields';
+
+export default TextareaField;

--- a/src/pf-4-form-fields/checkbox-lazy.js
+++ b/src/pf-4-form-fields/checkbox-lazy.js
@@ -1,0 +1,3 @@
+import { CheckboxGroup } from './form-fields';
+
+export default CheckboxGroup;

--- a/src/pf-4-form-fields/component-mapper.js
+++ b/src/pf-4-form-fields/component-mapper.js
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { components } from '../constants';
-import { TextField, TextareaField, SelectField, CheckboxGroup, SubForm, RadioGroup } from './form-fields';
-import { renderArrayField } from '../shared-components/array-form-component';
+
+const renderArrayField = lazy(() => import('../shared-components/array-form-component'));
+const TextField = lazy(() => import('./text-field-lazy'));
+const TextareaField = lazy(() => import('./textarea-lazy'));
+const CheckboxGroup = lazy(() => import('./checkbox-lazy'));
+const RadioGroup = lazy(() => import('./radio-lazy'));
+const SelectField = lazy(() => import('./select-field-lazy'));
+const SubForm = lazy(() => import('./sub-form-lazy'));
 
 const componentMapper = (componentType, formOptions) => ({
   [components.TEXT_FIELD]: props => <TextField { ...props } />,

--- a/src/pf-4-form-fields/radio-lazy.js
+++ b/src/pf-4-form-fields/radio-lazy.js
@@ -1,0 +1,3 @@
+import { RadioGroup } from './form-fields';
+
+export default RadioGroup;

--- a/src/pf-4-form-fields/select-field-lazy.js
+++ b/src/pf-4-form-fields/select-field-lazy.js
@@ -1,0 +1,3 @@
+import { SelectField } from './form-fields';
+
+export default SelectField;

--- a/src/pf-4-form-fields/sub-form-lazy.js
+++ b/src/pf-4-form-fields/sub-form-lazy.js
@@ -1,0 +1,3 @@
+import { SubForm } from './form-fields';
+
+export default SubForm;

--- a/src/pf-4-form-fields/text-field-lazy.js
+++ b/src/pf-4-form-fields/text-field-lazy.js
@@ -1,0 +1,3 @@
+import { TextField } from './form-fields';
+
+export default TextField;

--- a/src/pf-4-form-fields/textarea-lazy.js
+++ b/src/pf-4-form-fields/textarea-lazy.js
@@ -1,0 +1,3 @@
+import { TextareaField } from './form-fields';
+
+export default TextareaField;

--- a/src/shared-components/array-form-component.js
+++ b/src/shared-components/array-form-component.js
@@ -133,7 +133,7 @@ FixedArrayField.propTypes = {
   additionalItems: PropTypes.object.isRequired,
 };
 
-export const renderArrayField = (props, { hasFixedItems, renderForm }) => {
+const renderArrayField = (props, { hasFixedItems, renderForm }) => {
   const { key, validate, ...rest } = props;
   return (
     <Field name={ key } key={ key } subscription={{ pristine: true, error: true }}>
@@ -160,3 +160,5 @@ renderArrayField.propTypes = {
 renderArrayField.defaultProps = {
   validate: [],
 };
+
+export default renderArrayField;


### PR DESCRIPTION
Lazy loading form input components to decrease bundle size. In most cases, users will not use 100% of form components, in fact in all cases they will use at most 50% of form components (pf3 vs pf4) so it is not necessary to include all of them in main bundle.