### PR TITLE
fix(miqParser): added constants for missing components

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,6 +9,9 @@ export const components = {
   RADIO: 'radio-field',
   TABS: 'tabs',
   TAB_ITEM: 'tab-item',
+  DATE_PICKER: 'date-picker',
+  TIME_PICKER: 'time-picker',
+  TAG_CONTROL: 'tag-control',
 };
 /** Validator functions placeholder */
 export const validators = {

--- a/src/demo-schemas/array-scehma.js
+++ b/src/demo-schemas/array-scehma.js
@@ -1,12 +1,14 @@
+import { components } from '../constants/';
+
 export default {
   fields: [{
     title: 'A list of strings',
     key: 'listOfStrings',
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     itemDefault: 'bazinga',
     validate: [],
     fields: [{
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       dataType: 'string',
       type: 'text',
       validate: [],
@@ -20,7 +22,7 @@ export default {
     title: 'A multiple choices list',
     name: 'multipleChoicesList',
     label: 'A multiple choices list',
-    component: 'checkbox-field',
+    component: components.CHECKBOX,
     dataType: 'string',
     validate: [],
     options: [{
@@ -41,12 +43,12 @@ export default {
   }, {
     key: 'fixedItemsList',
     title: 'A list of fixed items',
-    component: 'fixed-list',
+    component: components.FIXED_LIST,
     fields: [{
       name: 'fixedItemsList.items.0',
       dataType: 'string',
       label: 'A string value',
-      component: 'textarea-field',
+      component: components.TEXTAREA_FIELD,
       default: 'lorem ipsum',
       validate: [],
     }, {
@@ -54,7 +56,7 @@ export default {
       dataType: 'boolean',
       label: 'a boolean value',
       validate: [],
-      component: 'select-field',
+      component: components.SELECT_COMPONENT,
       options: [{
         disabled: true,
         label: 'Please Choose',
@@ -69,12 +71,12 @@ export default {
     additionalItems: {
       key: 'fixedItemsList.additionalItems',
       validate: [],
-      component: 'field-array',
+      component: components.FIELD_ARRAY,
       fields: [{
         initialKey: 'items',
         dataType: 'number',
         label: 'Additional item',
-        component: 'text-field',
+        component: components.TEXT_FIELD,
         type: 'number',
         validate: [],
         autoFocus: false,
@@ -84,7 +86,7 @@ export default {
     },
   }, {
     key: 'minItemsList',
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     title: 'A list with a minimal number of items',
     validate: [{
       type: 'required-validator',
@@ -98,7 +100,7 @@ export default {
       name: 'minItemsList.name',
       dataType: 'string',
       default: 'Default name',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'text',
       validate: [],
       autoFocus: false,
@@ -108,7 +110,7 @@ export default {
     },
   }, {
     key: 'defaultsAndMinItems',
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     title: 'List and item level defaults',
     itemDefault: 'unidentified',
     validate: [{
@@ -117,7 +119,7 @@ export default {
     }],
     fields: [{
       dataType: 'string',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'text',
       validate: [],
       initialKey: 'items',
@@ -129,15 +131,15 @@ export default {
     key: 'nestedList',
     name: 'nestedList',
     title: 'Nested list',
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     fields: [{
       title: 'Inner list',
-      component: 'field-array',
+      component: components.FIELD_ARRAY,
       validate: [],
       key: 'nestedList',
       fields: [{
         dataType: 'string',
-        component: 'text-field',
+        component: components.TEXT_FIELD,
         validate: [],
         type: 'text',
         initialKey: 'items',
@@ -147,13 +149,13 @@ export default {
       }],
     }],
   }, {
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     key: 'unorderable',
     title: 'Unorderable items',
     validate: [],
     fields: [{
       dataType: 'string',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'text',
       validate: [],
       initialKey: 'items',
@@ -165,11 +167,11 @@ export default {
   }, {
     key: 'unremovable',
     title: 'Unremovable items',
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     validate: [],
     fields: [{
       dataType: 'string',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'text',
       validate: [],
       name: 'unremovable.items',
@@ -181,11 +183,11 @@ export default {
   }, {
     key: 'noToolbar',
     title: 'No add, remove and order buttons',
-    component: 'field-array',
+    component: components.FIELD_ARRAY,
     validate: [],
     fields: [{
       dataType: 'string',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'text',
       validate: [],
       name: 'noToolbar.items',
@@ -197,31 +199,31 @@ export default {
   }, {
     key: 'fixedNoToolbar',
     title: 'Fixed array without buttons',
-    component: 'fixed-list',
+    component: components.FIXED_LIST,
     fields: [{
       dataType: 'number',
       name: 'fixedNoToolbar.items.0',
       label: 'A number',
       default: 42,
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'number',
       validate: [],
     }, {
       name: 'fixedNoToolbar.items.1',
       dataType: 'boolean',
       label: 'A boolean',
-      component: 'checkbox-field',
+      component: components.CHECKBOX,
       type: 'checkbox',
       validate: [],
       default: false,
     }],
     additionalItems: {
-      component: 'field-array',
+      component: components.FIELD_ARRAY,
       key: 'fixedNoToolbar.additionalItems',
       validate: [],
       fields: [{
         dataType: 'string',
-        component: 'text-field',
+        component: components.TEXT_FIELD,
         label: 'A string',
         title: 'A string',
         initialKey: 'items',

--- a/src/demo-schemas/manage-iq-schemas/output.js
+++ b/src/demo-schemas/manage-iq-schemas/output.js
@@ -460,7 +460,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'datepicker',
+                component: 'date-picker',
                 options: [
 
                 ],
@@ -475,7 +475,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'datepicker',
+                component: 'date-picker',
                 options: [
 
                 ],
@@ -497,7 +497,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'timepicker',
+                component: 'time-picker',
                 options: [
 
                 ],
@@ -512,7 +512,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'timepicker',
+                component: 'time-picker',
                 options: [
 
                 ],
@@ -542,7 +542,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'tagcontrol',
+                component: 'tag-control',
                 options: [
 
                 ],
@@ -557,7 +557,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'tagcontrol',
+                component: 'tag-control',
                 options: [
 
                 ],
@@ -572,7 +572,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'tagcontrol',
+                component: 'tag-control',
                 options: [
                   {
 
@@ -729,7 +729,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'timepicker',
+                component: 'time-picker',
                 options: [
 
                 ],

--- a/src/demo-schemas/manage-iq-schemas/output.js
+++ b/src/demo-schemas/manage-iq-schemas/output.js
@@ -1,4 +1,6 @@
 /* eslint-disable camelcase */
+import { components } from '../../constants/';
+
 const output = {
   title: 'Testing dialog',
   description: 'Description of testing Dialog',
@@ -23,7 +25,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -38,7 +40,7 @@ const output = {
                 isReadOnly: false,
                 helperText: 'Helper text',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -53,7 +55,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -68,7 +70,7 @@ const output = {
                 isReadOnly: true,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -83,7 +85,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -98,7 +100,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -113,7 +115,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -128,7 +130,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -143,13 +145,13 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
           {
             title: 'Text areas',
@@ -165,16 +167,16 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'textarea-field',
+                component: components.TEXTAREA_FIELD,
                 options: [
 
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
         ],
-        component: 'tab-item',
+        component: components.TAB_ITEM,
       },
       {
         title: 'Tab 2',
@@ -195,7 +197,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'checkbox-field',
+                component: components.CHECKBOX,
                 options: [
 
                 ],
@@ -210,13 +212,13 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'checkbox-field',
+                component: components.CHECKBOX,
                 options: [
 
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
           {
             title: 'Radios',
@@ -232,7 +234,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'radio-field',
+                component: components.RADIO,
                 options: [
                   {
                     label: 'One',
@@ -258,7 +260,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'radio-field',
+                component: components.RADIO,
                 options: [
                   {
                     label: 'One',
@@ -284,7 +286,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'radio-field',
+                component: components.RADIO,
                 options: [
                   {
                     label: 'One',
@@ -301,10 +303,10 @@ const output = {
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
         ],
-        component: 'tab-item',
+        component: components.TAB_ITEM,
       },
       {
         title: 'Tab 3',
@@ -325,7 +327,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'select-field',
+                component: components.SELECT_COMPONENT,
                 options: [
                   {
                     label: '<None>',
@@ -355,7 +357,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'select-field',
+                component: components.SELECT_COMPONENT,
                 options: [
                   {
                     label: '<None>',
@@ -385,7 +387,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'select-field',
+                component: components.SELECT_COMPONENT,
                 options: [
                   {
                     label: '<None>',
@@ -415,7 +417,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'select-field',
+                component: components.SELECT_COMPONENT,
                 options: [
                   {
                     label: '<None>',
@@ -436,10 +438,10 @@ const output = {
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
         ],
-        component: 'tab-item',
+        component: components.TAB_ITEM,
       },
       {
         title: 'Tab 4',
@@ -460,7 +462,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'date-picker',
+                component: components.DATE_PICKER,
                 options: [
 
                 ],
@@ -475,13 +477,13 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'date-picker',
+                component: components.DATE_PICKER,
                 options: [
 
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
           {
             title: 'Timepickers',
@@ -497,7 +499,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'time-picker',
+                component: components.TIME_PICKER,
                 options: [
 
                 ],
@@ -512,16 +514,16 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'time-picker',
+                component: components.TIME_PICKER,
                 options: [
 
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
         ],
-        component: 'tab-item',
+        component: components.TAB_ITEM,
       },
       {
         title: 'Tab 5',
@@ -542,7 +544,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'tag-control',
+                component: components.TAG_CONTROL,
                 options: [
 
                 ],
@@ -557,7 +559,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'tag-control',
+                component: components.TAG_CONTROL,
                 options: [
 
                 ],
@@ -572,7 +574,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'tag-control',
+                component: components.TAG_CONTROL,
                 options: [
                   {
 
@@ -589,10 +591,10 @@ const output = {
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
         ],
-        component: 'tab-item',
+        component: components.TAB_ITEM,
       },
       {
         title: 'Mixed',
@@ -613,7 +615,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'text-field',
+                component: components.TEXT_FIELD,
                 options: [
 
                 ],
@@ -628,7 +630,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'textarea-field',
+                component: components.TEXTAREA_FIELD,
                 options: [
 
                 ],
@@ -643,7 +645,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'checkbox-field',
+                component: components.CHECKBOX,
                 options: [
 
                 ],
@@ -658,7 +660,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'checkbox-field',
+                component: components.CHECKBOX,
                 options: [
 
                 ],
@@ -673,7 +675,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'select-field',
+                component: components.SELECT_COMPONENT,
                 options: [
                   {
                     label: '<None>',
@@ -703,7 +705,7 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'radio-field',
+                component: components.RADIO,
                 options: [
                   {
                     label: 'One',
@@ -729,19 +731,19 @@ const output = {
                 isReadOnly: false,
                 helperText: '',
                 autofocus: false,
-                component: 'time-picker',
+                component: components.TIME_PICKER,
                 options: [
 
                 ],
               },
             ],
-            component: 'sub-form',
+            component: components.SUB_FORM,
           },
         ],
-        component: 'tab-item',
+        component: components.TAB_ITEM,
       },
     ],
-    component: 'tabs',
+    component: components.TABS,
     key: '57',
   },
 };

--- a/src/demo-schemas/widget-schema.js
+++ b/src/demo-schemas/widget-schema.js
@@ -1,3 +1,5 @@
+import { components } from '../constants/';
+
 export default {
   title: 'Widgets',
   fields: [{
@@ -6,7 +8,7 @@ export default {
     validate: [],
     key: 'stringFormats',
     title: 'String formats',
-    component: 'sub-form',
+    component: components.SUB_FORM,
     fields: [{
       initialKey: 'email',
       description: 'Insert your email address',
@@ -18,7 +20,7 @@ export default {
         treshold: 3,
       }],
       name: 'stringFormats.email',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'email',
       label: 'email',
       dataType: 'string',
@@ -27,7 +29,7 @@ export default {
       name: 'stringFormats.uri',
       label: 'uri',
       initialKey: 'uri',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       type: 'uri',
       dataType: 'string',
       validate: [],
@@ -39,7 +41,7 @@ export default {
     title: 'Boolean field',
     validate: [],
     key: 'boolean',
-    component: 'sub-form',
+    component: components.SUB_FORM,
     fields: [{
       name: 'boolean.default',
       initialKey: 'default',
@@ -48,7 +50,7 @@ export default {
       validate: [],
       autoFocus: false,
       description: 'This is the checkbox-description',
-      component: 'checkbox-field',
+      component: components.CHECKBOX,
       type: 'checkbox',
       dataType: 'boolean',
     }, {
@@ -59,7 +61,7 @@ export default {
       validate: [],
       autoFocus: false,
       description: 'This is the radio-description',
-      component: 'radio-field',
+      component: components.RADIO,
       type: 'radio',
       dataType: 'boolean',
       options: [{
@@ -75,7 +77,7 @@ export default {
       initialKey: 'select',
       title: 'select box',
       label: 'select box',
-      component: 'select-field',
+      component: components.SELECT_COMPONENT,
       type: 'boolean',
       dataType: 'boolean',
       validate: [{
@@ -98,7 +100,7 @@ export default {
     name: 'string',
     title: 'String field',
     validate: [],
-    component: 'sub-form',
+    component: components.SUB_FORM,
     key: 'string',
     fields: [{
       autoFocus: false,
@@ -107,7 +109,7 @@ export default {
       initialKey: 'default',
       type: 'text',
       dataType: 'string',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       title: 'text input (default)',
       label: 'text input (default)',
     }, {
@@ -118,7 +120,7 @@ export default {
       rows: 5,
       type: 'string',
       dataType: 'string',
-      component: 'textarea-field',
+      component: components.TEXTAREA_FIELD,
       title: 'textarea',
       label: 'textarea',
     }, {
@@ -128,7 +130,7 @@ export default {
       initialKey: 'color',
       type: 'color',
       dataType: 'string',
-      component: 'text-field',
+      component: components.TEXT_FIELD,
       title: 'color picker',
       label: 'color picker',
       default: '#151ce6',
@@ -138,7 +140,7 @@ export default {
     name: 'secret',
     type: 'hidden',
     dataType: 'string',
-    component: 'text-field',
+    component: components.TEXT_FIELD,
     default: 'I\'m a hidden string.',
   }, {
     autoFocus: false,
@@ -146,7 +148,7 @@ export default {
     name: 'disabled',
     type: 'text',
     dataType: 'string',
-    component: 'text-field',
+    component: components.TEXT_FIELD,
     title: 'A disabled field',
     label: 'A disabled field',
     default: 'I am disabled.',
@@ -157,7 +159,7 @@ export default {
     name: 'readonly',
     type: 'text',
     dataType: 'string',
-    component: 'text-field',
+    component: components.TEXT_FIELD,
     title: 'A readonly field',
     label: 'A readonly field',
     default: 'I am read-only.',
@@ -168,7 +170,7 @@ export default {
     name: 'widgetOptions',
     type: 'text',
     dataType: 'string',
-    component: 'text-field',
+    component: components.TEXT_FIELD,
     title: 'Custom widget with options',
     label: 'Custom widget with options',
     default: 'I am yellow',
@@ -178,7 +180,7 @@ export default {
     name: 'selectWidgetOptions',
     type: 'string',
     dataType: 'string',
-    component: 'select-field',
+    component: components.SELECT_COMPONENT,
     title: 'Custom select widget with options',
     label: 'Custom select widget with options',
     options: [{

--- a/src/parsers/manage-iq-parser/constants.js
+++ b/src/parsers/manage-iq-parser/constants.js
@@ -6,9 +6,9 @@ export const componentMap = {
   DialogFieldCheckBox: components.CHECKBOX,
   DialogFieldTextAreaBox: components.TEXTAREA_FIELD,
   DialogFieldDropDownList: components.SELECT_COMPONENT,
-  DialogFieldDateControl: 'datepicker',
-  DialogFieldDateTimeControl: 'timepicker',
-  DialogFieldTagControl: 'tagcontrol',
+  DialogFieldDateControl: components.DATE_PICKER,
+  DialogFieldDateTimeControl: components.TIME_PICKER,
+  DialogFieldTagControl: components.TAG_CONTROL,
 };
 
 export const neededAttributes = [

--- a/src/parsers/manage-iq-parser/miqParser.js
+++ b/src/parsers/manage-iq-parser/miqParser.js
@@ -33,7 +33,7 @@ const miqParser = (inputSchema, neededFieldAttributes, componentMap) => {
         newField.component = componentMap[field.type];
 
         if (field.default_value) {
-          if (newField.component === 'checkbox-field') {
+          if (newField.component === components.CHECKBOX) {
             defaultValues[field.name] = 'true';
           } else {
             defaultValues[field.name] = field.default_value;

--- a/src/parsers/manage-iq-parser/miqParser.js
+++ b/src/parsers/manage-iq-parser/miqParser.js
@@ -1,6 +1,7 @@
 import { components, validators } from '../../constants';
+import { neededAttributes, componentMap } from './constants';
 
-const miqParser = (inputSchema, neededFieldAttributes, componentMap) => {
+const miqParser = (inputSchema, neededFieldAttributes = neededAttributes, componentsMap = componentMap) => {
   const title = inputSchema.label;
   const key = inputSchema.id;
   const tabs = inputSchema.content[0].dialog_tabs;
@@ -30,7 +31,7 @@ const miqParser = (inputSchema, neededFieldAttributes, componentMap) => {
           }];
         }
 
-        newField.component = componentMap[field.type];
+        newField.component = componentsMap[field.type];
 
         if (field.default_value) {
           if (newField.component === components.CHECKBOX) {

--- a/src/parsers/manage-iq-parser/miqParser.test.js
+++ b/src/parsers/manage-iq-parser/miqParser.test.js
@@ -1,11 +1,10 @@
 import miqParse from './miqParser';
 import inputJSON from '../../demo-schemas/manage-iq-schemas/input';
 import outputJSON, { defaultValues } from '../../demo-schemas/manage-iq-schemas/output';
-import { neededAttributes, componentMap } from './constants';
 
 describe('miqParser', () => {
   it('Should parse schema and default values correctly ', () => {
-    const output = miqParse(inputJSON, neededAttributes, componentMap);
+    const output = miqParse(inputJSON);
     expect(output.schema).toEqual(outputJSON);
     expect(output.defaultValues).toEqual(defaultValues);
   });


### PR DESCRIPTION
- Added constants for missing components (from miq schema)

Right now, we have all components in `constants/index.js`, which are needed to parse miq-schemas. (And after adding them, we don't need to change parser.)

- Also fixed a string name of components used in the parser => changed to the constant.
- Replaced strings in demo-schemas to constants
- Made input variables in miqParser optional